### PR TITLE
User Profile Edit and Inactive Items Don't Show

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,7 @@ class ItemsController<ApplicationController
       @merchant = Merchant.find(params[:merchant_id])
       @items = @merchant.items
     else
-      @items = Item.all
+      @items = Item.where(active?: true)
     end
   end
 

--- a/app/controllers/users/users_controller.rb
+++ b/app/controllers/users/users_controller.rb
@@ -7,4 +7,27 @@ class Users::UsersController < Users::BaseController
     @user = current_user
   end
 
+  def update
+    if current_user.update(user_params)
+      if params[:user][:password]
+        flash[:notice] = "Password Updated!"
+        return redirect_to '/profile'
+      end
+      flash[:notice] = "Profile Updated!"
+      redirect_to '/profile'
+    else
+      flash[:error] = current_user.errors.full_messages.to_sentence
+      redirect_to "/profile/edit"
+    end
+  end
+
+  def change_password
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:name, :street_address, :city, :state, :zip, :email, :password, :password_confirmation)
+    end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   has_secure_password
-  validates_presence_of :name, :street_address, :city, :state, :zip, :role, :password
+  validates_presence_of :name, :street_address, :city, :state, :zip, :role, :password_digest
   validates :email, uniqueness: true, presence: true
 
   enum role: %w( User MerchantEmployee Admin )

--- a/app/views/users/users/change_password.html.erb
+++ b/app/views/users/users/change_password.html.erb
@@ -1,0 +1,12 @@
+<h2>Change Password</h2>
+
+<%= form_for current_user, url: '/users', method: :patch do |f|%>
+
+    <%= f.label :password %>
+    <%= f.password_field :password %>
+
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation %>
+
+  <%= f.submit "Update Password" %>
+<% end %>

--- a/app/views/users/users/show.html.erb
+++ b/app/views/users/users/show.html.erb
@@ -24,5 +24,6 @@
   </table>
   <br>
   <%= link_to 'Edit Profile', profile_edit_path %>
+  <%= link_to 'Change Password', "/profile/edit/password" %>
 </section>
 

--- a/app/views/visitors/users/_form.html.erb
+++ b/app/views/visitors/users/_form.html.erb
@@ -16,12 +16,13 @@
 
   <%= f.label :email %>
   <%= f.email_field :email %>
+  <% if current_user == nil %>
+    <%= f.label :password %>
+    <%= f.password_field :password %>
 
-  <%= f.label :password, hidden: (true if current_user != nil) %>
-  <%= f.password_field :password, hidden: (true if current_user != nil) %>
-
-  <%= f.label :password_confirmation, hidden: (true if current_user != nil) %>
-  <%= f.password_field :password_confirmation, hidden: (true if current_user != nil) %>
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation %>
+  <% end %>
 
   <%= f.submit button_text %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     # resource :profile, only: [:update]
     get '/profile', to: 'users#show'
     get '/profile/edit', to: 'users#edit'
+    get '/profile/edit/password', to: 'users#change_password'
     patch '/users', to: 'users#update'
   end
 

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -12,18 +12,17 @@ RSpec.describe "Items Index Page" do
       @dog_bone = @brian.items.create(name: "Dog Bone", description: "They'll love it!", price: 21, image: "https://img.chewy.com/is/image/catalog/54226_MAIN._AC_SL1500_V1534449573_.jpg", active?:false, inventory: 21)
     end
 
-    it "all items or merchant names are links" do
+    it "all items or merchant names are links without active items" do
       visit '/items'
 
       expect(page).to have_link(@tire.name)
       expect(page).to have_link(@tire.merchant.name)
       expect(page).to have_link(@pull_toy.name)
       expect(page).to have_link(@pull_toy.merchant.name)
-      expect(page).to have_link(@dog_bone.name)
-      expect(page).to have_link(@dog_bone.merchant.name)
+
     end
 
-    it "I can see a list of all of the items "do
+    it "I can see a list of all active items "do
 
       visit '/items'
 
@@ -47,15 +46,12 @@ RSpec.describe "Items Index Page" do
         expect(page).to have_css("img[src*='#{@pull_toy.image}']")
       end
 
-      within "#item-#{@dog_bone.id}" do
-        expect(page).to have_link(@dog_bone.name)
-        expect(page).to have_content(@dog_bone.description)
-        expect(page).to have_content("Price: $#{@dog_bone.price}")
-        expect(page).to have_content("Inactive")
-        expect(page).to have_content("Inventory: #{@dog_bone.inventory}")
-        expect(page).to have_link(@brian.name)
-        expect(page).to have_css("img[src*='#{@dog_bone.image}']")
-      end
+    end
+
+    it 'shouldnt show inactive items' do
+      visit '/items'
+
+      expect(page).to_not have_content(@dog_bone.name)
     end
   end
 end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe "User Profile Edit Page", type: :feature do
   before :each do
     @user = create(:user)
+    @user2 = create(:user, email: "test2@email.com")
     
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
   end
@@ -24,9 +25,41 @@ RSpec.describe "User Profile Edit Page", type: :feature do
 
       click_on "Update Profile"
 
-      expect(current_path).to have_content("Profile Updated")
-      expect(page).to have_content("Name Edited")
+      expect(current_path).to have_content("/profile")
+      expect(page).to have_content("Profile Updated!")
+    end
 
+    it 'cant change to an email already taken' do
+      visit '/profile'
+      click_on 'Edit Profile'
+      
+      expect(find_field('Name').value).to eq "#{@user.name}"
+      expect(find_field('Street address').value).to eq "#{@user.street_address}"
+      expect(find_field('City').value).to eq "#{@user.city}"
+      expect(find_field('State').value).to eq "#{@user.state}"
+      expect(find_field('Zip').value).to eq "#{@user.zip}"
+      expect(find_field('Email').value).to eq "#{@user.email}"
+      expect(page).not_to have_content("Password")
+      
+      fill_in :Email, with: "test2@email.com"
+
+      click_on "Update Profile"
+
+      expect(current_path).to have_content("/profile/edit")
+      expect(page).to have_content("Email has already been taken")
+    end
+
+    it 'can change its password' do
+      visit '/profile'
+      click_on 'Change Password'
+
+      fill_in :Password, with: "password2"
+      fill_in :user_password_confirmation, with: "password2"
+
+      click_on "Update Password"
+
+      expect(current_path).to eq("/profile")
+      expect(page).to have_content("Password Updated")
     end
   end
 end

--- a/spec/features/users/profile_spec.rb
+++ b/spec/features/users/profile_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'User Profile Page', type: :feature do
   end
 
   context 'as a registered user' do
-    it 'can see all profile data expect password with link to edit' do
+    it 'can see all profile data expect password with link to edit profile and edit password' do
       visit '/profile'
 
       within "#user-info" do
@@ -22,6 +22,7 @@ RSpec.describe 'User Profile Page', type: :feature do
         expect(page).not_to have_content(@user.password)
 
         expect(page).to have_link("Edit Profile")
+        expect(page).to have_link("Change Password")
       end
     end
   end


### PR DESCRIPTION
Users can now have access to editing their information.  Email uniqueness still intact.

Password Changing verifies matching inputs.

Item Index only shows active ideas for all users.