### PR TITLE
Item New Edit w/ Flash Messages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  helper_method :cart, :current_user
+  helper_method :cart, :current_user, :role, :employee?
 
   def cart
     @cart ||= Cart.new(session[:cart] ||= Hash.new(0))
@@ -13,5 +13,13 @@ class ApplicationController < ActionController::Base
 
   def role 
     current_user.role if current_user
+  end
+
+  def employee?
+    if current_user
+      return current_user.merchants.first == @merchant
+    else
+      false
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  helper_method :cart, :current_user, :role, :employee?
+  helper_method :cart, :current_user, :role, :employee?, :has_rights?
 
   def cart
     @cart ||= Cart.new(session[:cart] ||= Hash.new(0))
@@ -18,6 +18,14 @@ class ApplicationController < ActionController::Base
   def employee?
     if current_user
       return current_user.merchants.first == @merchant
+    else
+      false
+    end
+  end
+
+  def has_rights?
+    if current_user
+      return current_user.merchants.first == @item.merchant
     else
       false
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -15,15 +15,18 @@ class ItemsController<ApplicationController
 
   def new
     @merchant = Merchant.find(params[:merchant_id])
+    @item = Item.new
   end
 
   def create
     @merchant = Merchant.find(params[:merchant_id])
-    item = @merchant.items.create(item_params)
-    if item.save
+    params.delete params[:item][:image] if ( (params[:item][:image].blank?))
+    @item = @merchant.items.create(item_params)
+    if @item.save
+      flash[:notice] = "#{@item.name} is saved and ready for sale!"
       redirect_to "/merchants/#{@merchant.id}/items"
     else
-      flash[:error] = item.errors.full_messages.to_sentence
+      flash[:error] = @item.errors.full_messages.to_sentence
       render :new
     end
   end
@@ -34,8 +37,10 @@ class ItemsController<ApplicationController
 
   def update
     @item = Item.find(params[:id])
+    params.delete params[:item][:image] if ( (params[:item][:image].blank?))
     @item.update(item_params)
     if @item.save
+      flash[:notice] = "#{@item.name} has been edited!"
       redirect_to "/items/#{@item.id}"
     else
       flash[:error] = @item.errors.full_messages.to_sentence
@@ -53,7 +58,7 @@ class ItemsController<ApplicationController
   private
 
   def item_params
-    params.permit(:name,:description,:price,:inventory,:image)
+    params.require(:item).permit(:name,:description,:price,:inventory,:image)
   end
 
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -4,9 +4,9 @@ class OrdersController <ApplicationController
 
   end
 
-  def show
-    @order = Order.find(params[:id])
-  end
+  # def show
+  #   @order = Order.find(params[:id])
+  # end
 
   def create
     order = current_user.orders.create(order_params)

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -37,4 +37,8 @@ class Merchant <ApplicationRecord
     items.update(active?: true)
   end
 
+  def employee?
+    require 'pry'; binding.pry
+  end
+
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -37,8 +37,4 @@ class Merchant <ApplicationRecord
     items.update(active?: true)
   end
 
-  def employee?
-    require 'pry'; binding.pry
-  end
-
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,22 +1,23 @@
 <h1>Edit <%=link_to @item.name, "/items/#{@item.id}" %></h1>
 
 <center>
-  <%= form_tag "/items/#{@item.id}", method: :patch  do %>
-    <%= label_tag :name %>
-    <%= text_field_tag :name, "#{@item.name}"%>
+  <%= form_for @item, url: "/items/#{@item.id}", method: :patch do |f| %>
+    <%= f.label :name %>
+    <%= f.text_field :name, value: @item.name %>
 
-    <%= label_tag :description %>
-    <%= text_field_tag :description, "#{@item.description}" %>
+    <%= f.label :description %>
+    <%= f.text_field :description, value: @item.description %>
 
-    <%= label_tag :price %>
-    <%= text_field_tag :price, "#{number_to_currency(@item.price)}" %>
+    <%= f.label :price %>
+    <%= f.number_field :price, value: @item.price, min: 0.5, step: 0.5 %>
+    <br>
+    <%= f.label :image %>
+    <%= f.text_field :image, value: @item.image %>
 
-    <%= label_tag :image %>
-    <%= text_field_tag :image, "#{@item.image}" %>
+    <%= f.label :inventory %>
+    <%= f.number_field :inventory, value: @item.inventory, min: 0 %>
 
-    <%= label_tag :inventory %>
-    <%= text_field_tag :inventory, "#{@item.inventory}" %>
-
-    <%= submit_tag 'Update Item' %>
+    <%= f.submit 'Update Item' %>
   <% end %>
 </center>
+

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,4 +1,4 @@
-<% if @merchant %>
+<% if @merchant && employee? %>
   <h1><%= link_to @merchant.name, "/merchants/#{@merchant.id}"%><span> Items</span></h1>
   <p align="center"><%= link_to "Add New Item", "/merchants/#{@merchant.id}/items/new" %></p>
 <% else %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,22 +1,22 @@
 <h1>Create New Item For <%=link_to @merchant.name, "/merchants/#{@merchant.id}" %></h1>
 
 <center>
-  <%= form_tag "/merchants/#{@merchant.id}/items", method: :post do %>
-    <%= label_tag :name %>
-    <%= text_field_tag :name%>
+  <%= form_for @item, url: "/merchants/#{@merchant.id}/items", method: :post do |f| %>
+    <%= f.label :name %>
+    <%= f.text_field :name, value: @item.name %>
 
-    <%= label_tag :description %>
-    <%= text_field_tag :description %>
+    <%= f.label :description %>
+    <%= f.text_field :description, value: @item.description %>
 
-    <%= label_tag :price %>
-    <%= text_field_tag :price %>
+    <%= f.label :price %>
+    <%= f.number_field :price, value: @item.price, min: 0.5, step: 0.5 %>
+    <br>
+    <%= f.label :image %>
+    <%= f.text_field :image, value: @item.image %>
 
-    <%= label_tag :image %>
-    <%= text_field_tag :image %>
+    <%= f.label :inventory %>
+    <%= f.number_field :inventory, value: @item.inventory, min: 0 %>
 
-    <%= label_tag :inventory %>
-    <%= text_field_tag :inventory %>
-
-    <%= submit_tag 'Create Item' %>
+    <%= f.submit 'Create Item' %>
   <% end %>
 </center>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -17,8 +17,10 @@
       <% else %>
         <p style= "color:red">Inactive</p>
       <% end %>
-      <p><%= link_to "Edit Item", "/items/#{@item.id}/edit" %></p>
-      <p><%= link_to "Delete Item", "/items/#{@item.id}", method: :delete if @item.no_orders?%></p>
+      <% if has_rights? %>
+        <p><%= link_to "Edit Item", "/items/#{@item.id}/edit" %></p>
+        <p><%= link_to "Delete Item", "/items/#{@item.id}", method: :delete if @item.no_orders?%></p>
+      <% end %>
       <%= link_to "Add Review", "/items/#{@item.id}/reviews/new" %>
       <%= button_to "Add To Cart", "/cart/#{@item.id}", method: :post %>
     </section>

--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -1,5 +1,8 @@
 <h2>My Shop's Iitems</h2>
 
+  <p align="center"><%= link_to "Add New Item", "/merchants/#{@items.first.merchant_id}/items/new" %></p>
+
+
 <table class = "cart-items">
   <tr>
     <th>Item</th>
@@ -30,7 +33,7 @@
       </td>
 
       <td>
-        <%= item.active? %>
+        <%= item.active? ? "Active" : "Inactive" %>
       </td>
 
       <td>

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -3,10 +3,10 @@
 <section class = "grid-container">
   <% @merchants.each do |merchant|%>
     <section class = "grid-item">
-    <% if current_user == "MerchantEmployee"%>
-      <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
-    <% else current_user == "Admin"%>
+    <% if role == "Admin"%>
       <h2><%=link_to merchant.name, "/admin/merchants/#{merchant.id}"%></h2>
+    <% else %>
+      <h2><%=link_to merchant.name, "/merchants/#{merchant.id}"%></h2>
     <% end %>
     </section>
   <% end %>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -3,8 +3,12 @@
 <p class="address"><%= @merchant.city %>, <%= @merchant.state %> <%= @merchant.zip %></p>
 
 <ul><%= link_to "All #{@merchant.name} Items", "/merchants/#{@merchant.id}/items" %></ul>
-<ul><%= link_to "Update Merchant", "/merchants/#{@merchant.id}/edit" %></ul>
-<ul><%= link_to "Delete Merchant", "/merchants/#{@merchant.id}", method: :delete  if @merchant.no_orders?%>
+<% if employee? %>
+  <ul><%= link_to "Update Merchant", "/merchants/#{@merchant.id}/edit" %></ul>
+<% end %>
+<% if role == "Admin" %>
+  <ul><%= link_to "Delete Merchant", "/merchants/#{@merchant.id}", method: :delete  if @merchant.no_orders?%>
+<% end %>
 </ul>
 <section class = "merchant-stats">
   <h2>Number of Items: <%=@merchant.item_count%></h2>

--- a/db/migrate/20190817190207_create_items.rb
+++ b/db/migrate/20190817190207_create_items.rb
@@ -3,8 +3,8 @@ class CreateItems < ActiveRecord::Migration[5.1]
     create_table :items do |t|
       t.string :name
       t.string :description
-      t.integer :price
-      t.string :image
+      t.float :price
+      t.string :image, default: "https://www.wpclipart.com/office/sale_promo/new_item/new_item_light_red.png"
       t.boolean :active?, default: true
       t.integer :inventory
       t.references :merchant, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,8 +30,8 @@ ActiveRecord::Schema.define(version: 20200225022020) do
   create_table "items", force: :cascade do |t|
     t.string "name"
     t.string "description"
-    t.integer "price"
-    t.string "image"
+    t.float "price"
+    t.string "image", default: "https://www.wpclipart.com/office/sale_promo/new_item/new_item_light_red.png"
     t.boolean "active?", default: true
     t.integer "inventory"
     t.bigint "merchant_id"

--- a/spec/features/employees/dashboard_spec.rb
+++ b/spec/features/employees/dashboard_spec.rb
@@ -2,11 +2,10 @@ require 'rails_helper'
 
 RSpec.describe "As an merchant employee,", type: :feature do
     before :each do
-        @user = create(:user, name: "Francisco", role: 1)
         @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
-
+        @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+        @user = create(:user, name: "Francisco", role: 1)
         @bike_shop.users << @user
-        
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     end
 

--- a/spec/features/employees/items_spec.rb
+++ b/spec/features/employees/items_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe "Merchant Dashboard My Items Page" do
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
   end
+
+  it 'can see a button to add a new item' do
+    visit "/merchant/items"
+
+    expect(page).to have_link("New Item")
+  end
   it "can see a delete button next to each item" do
 
     visit "/merchant/items"

--- a/spec/features/items/destroy_spec.rb
+++ b/spec/features/items/destroy_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe 'item delete', type: :feature do
     it 'I can delete an item' do
       bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      user = create(:user, role: 1)
+      bike_shop.users << user
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       visit "/items/#{chain.id}"
 
@@ -20,6 +23,9 @@ RSpec.describe 'item delete', type: :feature do
       bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
       review_1 = chain.reviews.create(title: "Great place!", content: "They have great bike stuff and I'd recommend them to anyone.", rating: 5)
+      user = create(:user, role: 1)
+      bike_shop.users << user
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
       visit "/items/#{chain.id}"
 

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -3,9 +3,14 @@ require 'rails_helper'
 RSpec.describe "As a Visitor" do
   describe "When I visit an Item Show Page" do
     describe "and click on edit item" do
-      it 'I can see the prepopulated fields of that item' do
+      before :each do
         @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
         @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+        @user = create(:user, name: "Francisco", role: 1)
+        @meg.users << @user
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      end
+      it 'I can see the prepopulated fields of that item' do
 
         visit "/items/#{@tire.id}"
 
@@ -16,16 +21,14 @@ RSpec.describe "As a Visitor" do
         expect(current_path).to eq("/items/#{@tire.id}/edit")
         expect(page).to have_link("Gatorskins")
         expect(find_field('Name').value).to eq "Gatorskins"
-        expect(find_field('Price').value).to eq '$100.00'
+        expect(find_field('Price').value).to eq '100.0'
         expect(find_field('Description').value).to eq "They'll never pop!"
         expect(find_field('Image').value).to eq("https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588")
         expect(find_field('Inventory').value).to eq '12'
       end
 
       it 'I can change and update item with the form' do
-        @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-        @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-
+      
         visit "/items/#{@tire.id}"
 
         click_on "Edit Item"
@@ -50,9 +53,7 @@ RSpec.describe "As a Visitor" do
       end
 
       it 'I get a flash message if entire form is not filled out' do
-        @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
-        @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
-
+        
         visit "/items/#{@tire.id}"
 
         click_on "Edit Item"
@@ -65,7 +66,7 @@ RSpec.describe "As a Visitor" do
 
         click_button "Update Item"
 
-        expect(page).to have_content("Name can't be blank and Image can't be blank")
+        expect(page).to have_content("Name can't be blank")
         expect(page).to have_button("Update Item")
       end
     end

--- a/spec/features/items/new_spec.rb
+++ b/spec/features/items/new_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe "Create Merchant Items" do
   describe "When I visit the merchant items index page" do
     before(:each) do
       @brian = Merchant.create(name: "Brian's Dog Shop", address: '125 Doggo St.', city: 'Denver', state: 'CO', zip: 80210)
+      @user = create(:user, name: "Francisco", role: 1)
+      @brian.users << @user
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     end
 
     it 'I see a link to add a new item for that merchant' do
@@ -25,11 +28,11 @@ RSpec.describe "Create Merchant Items" do
 
       expect(page).to have_link(@brian.name)
       expect(current_path).to eq("/merchants/#{@brian.id}/items/new")
-      fill_in :name, with: name
-      fill_in :price, with: price
-      fill_in :description, with: description
-      fill_in :image, with: image_url
-      fill_in :inventory, with: inventory
+      fill_in :Name, with: name
+      fill_in :Price, with: price
+      fill_in :Description, with: description
+      fill_in :Image, with: image_url
+      fill_in :Inventory, with: inventory
 
       click_button "Create Item"
 
@@ -51,6 +54,39 @@ RSpec.describe "Create Merchant Items" do
       expect(page).to have_content("Inventory: #{new_item.inventory}")
     end
 
+    it 'I can add a new item by filling out a form without an image' do
+      visit "/merchants/#{@brian.id}/items"
+
+      name = "Chamois Buttr"
+      price = 18
+      description = "No more chaffin'!"
+      inventory = 25
+
+      click_on "Add New Item"
+
+      expect(page).to have_link(@brian.name)
+      expect(current_path).to eq("/merchants/#{@brian.id}/items/new")
+      fill_in :Name, with: name
+      fill_in :Price, with: price
+      fill_in :Description, with: description
+      fill_in :Inventory, with: inventory
+
+      click_button "Create Item"
+
+      new_item = Item.last
+
+      expect(current_path).to eq("/merchants/#{@brian.id}/items")
+      "#{name} is saved and ready for sale!"
+
+      expect("#item-#{Item.last.id}").to be_present
+      expect(page).to have_content(name)
+      expect(page).to have_content("Price: $#{new_item.price}")
+      expect(page).to have_css("img[src*='#{new_item.image}']")
+      expect(page).to have_content("Active")
+      expect(page).to_not have_content(new_item.description)
+      expect(page).to have_content("Inventory: #{new_item.inventory}")
+    end
+
     it 'I get an alert if I dont fully fill out the form' do
       visit "/merchants/#{@brian.id}/items"
 
@@ -62,11 +98,11 @@ RSpec.describe "Create Merchant Items" do
 
       click_on "Add New Item"
 
-      fill_in :name, with: name
-      fill_in :price, with: price
-      fill_in :description, with: description
-      fill_in :image, with: image_url
-      fill_in :inventory, with: inventory
+      fill_in :Name, with: name
+      fill_in :Price, with: price
+      fill_in :Description, with: description
+      fill_in :Image, with: image_url
+      fill_in :Inventory, with: inventory
 
       click_button "Create Item"
 

--- a/spec/features/merchants/destroy_spec.rb
+++ b/spec/features/merchants/destroy_spec.rb
@@ -3,6 +3,9 @@ require 'rails_helper'
 RSpec.describe "As a visitor" do
   describe "When I visit a merchant show page" do
     it "I can delete a merchant" do
+      @user = create(:user, role: 2)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+
       bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
 
       visit "merchants/#{bike_shop.id}"
@@ -14,6 +17,8 @@ RSpec.describe "As a visitor" do
     end
 
     it "I can delete a merchant that has items" do
+      @user = create(:user, role: 2)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
       bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
 

--- a/spec/features/merchants/edit_spec.rb
+++ b/spec/features/merchants/edit_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 RSpec.describe "As a Visitor" do
   describe "After visiting a merchants show page and clicking on updating that merchant" do
     before :each do
+      @user = create(:user, role: 1)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
       @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 11234)
+      @bike_shop.users << @user
     end
     it 'I can see prepopulated info on that user in the edit form' do
       visit "/merchants/#{@bike_shop.id}"


### PR DESCRIPTION
Migration Needed

Items
-New and Edit forms have been changed to form_for.  They display appropriate flash messages for new and edit and any errors.
-These forms are only accessible by employees of that merchant

All tests that were broken by these access restrictions were modified to conform with app navigation restrictions